### PR TITLE
Make jellyfish run in NODE_ENV development

### DIFF
--- a/runservers
+++ b/runservers
@@ -148,6 +148,7 @@ tp_pool-whisperer() {
 tp_jellyfish() {
     export PORT=9122
     export SERVICE_NAME=jellyfish-local
+    export NODE_ENV=development
 
     tp_start_server jellyfish app.js
 }


### PR DESCRIPTION
Would it be all right if we set `NODE_ENV=development` for Jellyfish in `runservers`?

This will make the client-side portion of it build "on the fly", so you don't have to remember and build it manually when running all platform components...
