### PR TITLE
runservers uses tide-whisperer instead of pool-whisperer

### DIFF
--- a/get_current_tidepool_repos.sh
+++ b/get_current_tidepool_repos.sh
@@ -16,6 +16,7 @@ require gulp "Visit gulpjs.com to get it."
 require mocha "Visit http://visionmedia.github.io/mocha/ to get it."
 require cc "On a Mac, install XCode and its command line tools."
 require mongod "Visit mongodb.org to get it."
+require go "Visit golang.org to get it."
 
 if [ -f runservers ]; then
   cd ..

--- a/required_repos.txt
+++ b/required_repos.txt
@@ -4,7 +4,7 @@ highwater
 seagull
 armada
 message-api
-pool-whisperer
+tide-whisperer
 gatekeeper
 styx
 jellyfish

--- a/runservers
+++ b/runservers
@@ -58,6 +58,22 @@ tp_start_server() {   # expects servername, start name
     sleep 1
 }
 
+tp_go_server() {
+    echo "Starting $1"
+    cd $1 || return
+    OLD_GOPATH=${GOPATH}
+    export GOPATH=`pwd`; go install github.com/tidepool-org/$1
+    export GOPATH=${OLD_GOPATH}
+    # use the first line if you want individual logs, the 2nd if you want to aggregate them.
+    #./bin/$1 > ../$1.log 2>&1 &
+    ./bin/$1 >> ../server.log 2>&1  &
+    cd ..
+    PIDDY=$!
+    echo "Started $1, pid ${PIDDY}"
+    export TP_PIDS="$TP_PIDS $PIDDY"
+    sleep 1
+}
+
 # Everyone
 tp_common() {
     export API_SECRET="This is a local API secret for everyone. BsscSHqSHiwrBMJsEGqbvXiuIUPAjQXU"
@@ -138,12 +154,9 @@ tp_message_api() {
     tp_start_server message-api lib/index.js
 }
 
-# pool-whisperer
-tp_pool-whisperer() {
-    export PORT=9121
-    export SERVICE_NAME=pool-whisperer-local
-
-    tp_start_server pool-whisperer server.js
+# tide-whisperer
+tp_tide-whisperer() {
+    tp_go_server tide-whisperer
 }
 
 # jellyfish
@@ -211,7 +224,7 @@ tp_highwater || return
 tp_seagull || return
 tp_armada || return
 tp_message_api || return
-tp_pool-whisperer || return
+tp_tide-whisperer || return
 tp_gatekeeper || return
 tp_styx || return
 tp_jellyfish || return

--- a/styx_rules.json
+++ b/styx_rules.json
@@ -10,7 +10,7 @@
 	}
       },
       { "type": "pathPrefix", "prefix": "/auth", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9107"}]}},
-      { "type": "pathPrefix", "prefix": "/data", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9121"}]}},
+      { "type": "pathPrefix", "prefix": "/data", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9127"}]}},
       { "type": "pathPrefix", "prefix": "/group", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9118"}]}},
       { "type": "pathPrefix", "prefix": "/message", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9119"}]}},
       { "type": "pathPrefix", "prefix": "/metadata", "rule": { "type": "staticService", "hosts": [{ "protocol": "http", "host": "localhost:9120"}]}},


### PR DESCRIPTION
@kentquirk these are the changes to make runservers use tide-whisperer instead of pool-whisperer.

It works locally, so hopefully all is well.  I'm not sure if there is another place that I should update to indicate that you need to install go, but if there is, can you point me to it?
