### PR TITLE
Update the readme and scripts to reflect zuul instead of tidepool-groupedit

### DIFF
--- a/groupedit/README.md
+++ b/groupedit/README.md
@@ -3,32 +3,31 @@
 Cmd-line way to set up groups for a user
 
 ## Getting Started
-Install the module with: `npm install tidepool-groupedit`
+Install the module with: `npm install`
 
 ## Documentation
-    A server-side tool for adding and removing people to Tidepool groups.
+    A tool for manipulating Tidepool groups directly using gatekeeper.
 
-    -h, --help  help
-    -u, --user  set username containing the group to modify
-    -g, --group set group name to modify (default is team)
-    -c, --config set config name to use (default is 'config')
-    -a, --add   add members to the group
-    -d, --del   delete members from the group
-    -s, --status check and print status of the servers
+    -h, --help    help
+    -v, --verbose verbose logging
+    -c, --config  set config name to use (default is 'config')
+
+    zuul <group_id> <action> [arg, ...]
 
     Typical usage:
 
         To list people in a group:
-          tidepool-groupedit --group=patients --user=doctor@foo.com
-        To add people to a group on staging:
-          tidepool-groupedit --add --group=invited --user=patient@foo.com doctor@bar.com --config=staging
-        To list people in a group:
-          tidepool-groupedit --del --group=careteam --user=patient@foo.com dontcare@bar.com badguy@unsafe.com
+            `zuul doctor@foo.com show`
+        To add people to a group:
+            `zuul doctor@bar.com add patient@foo.com`
+        To remove people from a group:
+            `zuul dontcare@bear.com remove 12f4ebff81`
 
-        You can use either an email address or the userid to identify a user.
+        You can use either an email address or a userid to identify both a group and a user.
 
 ## Release History
 
+* 0.6.0 -- 10 Jul 2014 -- update to use gatekeeper, by Eric Tschetter
 * 0.5.0 -- 30 Mar 2014 -- initial version, by Kent Quirk
 
 ## License

--- a/groupedit/addToCareteam.sh
+++ b/groupedit/addToCareteam.sh
@@ -6,14 +6,5 @@
 if [ ! -e config/$1.json ]; then
     echo "config/$1.json doesn't exist"
 else
-    if lib/tidepool-pwreset.js --config=$1 --user=$2; then
-        if lib/tidepool-pwreset.js --config=$1 --user=$3; then
-            if lib/tidepool-groupedit.js --config=$1 --group=team  --user=$2 --add $3; then
-                echo "Added $3 to group 'team' of $2"
-            fi
-            if lib/tidepool-groupedit.js --config=$1 --group=patients --user=$3 --add $2; then
-                echo "Added $2 to group 'patients' of $3"
-            fi
-        fi
-    fi
+    node lib/zuul.js -c $1 $2 add $3
 fi

--- a/groupedit/addToCareteamGroupedit.sh
+++ b/groupedit/addToCareteamGroupedit.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+# usage: addToCareteam.sh staging a@a.com b@b.com
+# this put's b on a's careteam, and puts a on b's patients list.
+
+if [ ! -e config/$1.json ]; then
+    echo "config/$1.json doesn't exist"
+else
+    if lib/tidepool-pwreset.js --config=$1 --user=$2; then
+        if lib/tidepool-pwreset.js --config=$1 --user=$3; then
+            if lib/tidepool-groupedit.js --config=$1 --group=team  --user=$2 --add $3; then
+                echo "Added $3 to group 'team' of $2"
+            fi
+            if lib/tidepool-groupedit.js --config=$1 --group=patients --user=$3 --add $2; then
+                echo "Added $2 to group 'patients' of $3"
+            fi
+        fi
+    fi
+fi

--- a/groupedit/lib/zuul.js
+++ b/groupedit/lib/zuul.js
@@ -13,7 +13,7 @@ var configName = null;
 var parser = new Cmdline(
   {
     name: 'zuul',
-    desc: 'A tool for adding and removing people to Tidepool groups directly using the API.',
+    desc: 'A tool for manipulating Tidepool groups directly using the API.',
     extra: [
       '  zuul <group_id> <action> [arg, ...]',
       'Typical usage:\n',
@@ -54,6 +54,7 @@ var args = parser.getArguments();
 
 if (args.length < 2) {
   parser.printHelp();
+  return;
 }
 
 var handler, userApi, gatekeeper;
@@ -112,7 +113,7 @@ function determineHandler() {
         for (var i = 2; i < args.length; ++i) {
           var userToAdd = args[i];
           if (userToAdd == null) {
-            console.log('Got a null argument on command line at index[%s]!?', i)
+            console.log('Got a null argument on command line at index[%s]!?', i);
             continue;
           }
 
@@ -128,7 +129,7 @@ function determineHandler() {
 
               show(groupId, cb);
             });
-          })
+          });
         }
       };
     default:


### PR DESCRIPTION
I preserved the old addToCareteam.sh script as addToCareteamGroupedit.sh so that it is simple to have users use the old script if they have problems with the new one for some reason.

@kentquirk Just went to update things and realized that the script that we are using is a part of this repo.  Also realized I hadn't updated the readme, so I've done both of those in this PR.
