### PR TITLE
Build clamshell and blip in runservers

### DIFF
--- a/runservers
+++ b/runservers
@@ -163,7 +163,7 @@ tp_tide-whisperer() {
 tp_jellyfish() {
     export PORT=9122
     export SERVICE_NAME=jellyfish-local
-    export NODE_ENV=production
+    export SERVE_STATIC=dist
 
     if [ "$SKIP_BUILD" != "true" ]; then
       echo "Building Jellyfish..."


### PR DESCRIPTION
A set of changes to adapt `runservers` to new webpack workflow for Blip and Clamshell.

Basically we build both apps with a "local" config, then launch their static servers.

Since the build script is quite verbose, I redirect its output to `/dev/null`.

Since the build can take some time, I added to ability to set `export SKIP_BUILD=true` before running the `source tools/runservers`. But this is only "if you know what you are doing", i.e. by default it will always build.

@cheddar @kentquirk let me know what you think?

Thanks!

See https://github.com/tidepool-org/tools/issues/18
