### PR TITLE
Update get_current_tidepool_repos.sh to use bash

### DIFF
--- a/get_current_tidepool_repos.sh
+++ b/get_current_tidepool_repos.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 # This script depends on a list of current repositories found in tools/current_repos.txt
 # it checks a few requirements before running
 


### PR DESCRIPTION
`/bin/sh` is typically implemented as a symbolic to the `bash` shell.  Recent releases of Ubuntu change this implementation to point to another shell called `dash` ([reference](http://askubuntu.com/questions/141928/what-is-difference-between-bin-sh-and-bin-bash)).  This causes the script to fail on line 31 with the error `Syntax error: "(" unexpected`.

Changing the shell reference to `/bin/bash` allows the script to run.
