### PR TITLE
Fixes "bash: //so: no such file or directory" error

### DIFF
--- a/runservers
+++ b/runservers
@@ -216,7 +216,7 @@ tp_jellyfish() {
     export PORT=9122
     export SERVICE_NAME=jellyfish-local
     export SERVE_STATIC=dist
-    //so that we can validate the version of the uploader being used
+    # so that we can validate the version of the uploader being used
     export MINIMUM_UPLOADER_VERSION="0.99.0"
 
     if [ "$SKIP_BUILD" != "true" ]; then


### PR DESCRIPTION
When executing the runservers script, a non-critical error appears:
bash: //so: no such file or directory

This is because C++-style comments are used instead of bash-style
comments.