### PR TITLE
If NEW_SALT_DEPLOY is empty or not defined, no output encryption applied

### DIFF
--- a/migrate_metadata/README.md
+++ b/migrate_metadata/README.md
@@ -15,7 +15,7 @@ $ read -s OLD_SALT_DEPLOY
 <enter seagull old SALT_DEPLOY here>
 $ export OLD_SALT_DEPLOY
 
-# Set seagull NEW_SALT_DEPLOY
+# Set seagull NEW_SALT_DEPLOY (if empty will not apply encryption)
 $ read -s NEW_SALT_DEPLOY
 <enter seagull new SALT_DEPLOY here>
 $ export NEW_SALT_DEPLOY


### PR DESCRIPTION
@jh-bate Changes to the script to migrate metadata in the new environment.  If the NEW_SALT_DEPLOY is empty or not specified, then no encryption will be applied on the final metadata before it is stored back into the database.