### PR TITLE
Fixed dependency installation for git and mongod.

### DIFF
--- a/setup_vagrant.sh
+++ b/setup_vagrant.sh
@@ -3,6 +3,9 @@
 echo "Perform Update"
 apt-get update
 
+echo "Installing git..."
+apt-get install -y git
+
 echo "Installing htop..."
 apt-get install -y htop
 
@@ -36,7 +39,8 @@ npm install -g webpack
 echo "Installing MongoDB..."
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
-apt-get install -y mongodb-org=2.6.5 mongodb-org-server=2.6.5 mongodb-org-shell=2.6.5 mongodb-org-mongos=2.6.5 mongodb-org-tools=2.6.5
+apt-get update
+apt-get install -y --force-yes mongodb-org=2.6.5 mongodb-org-server=2.6.5 mongodb-org-shell=2.6.5 mongodb-org-mongos=2.6.5 mongodb-org-tools=2.6.5
 
 echo "Installing golang..."
 wget -qO- https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz | tar -C /usr/local/ -xzv


### PR DESCRIPTION
Git and mongod were not installing properly with the vagrant instructions in tools/README.md.

This PR adds a git install command, an apt-get update (needed to make use of the sources.list update on a prior line) and forces the install of mongod packages.

The force (--force-yes) is not a great solution, but I think it's a reasonable short-term fix for this testing/dev environment.  It squelches a warning about a failure relating to package signing key verification which should be taken seriously on a production machine.