### PR TITLE
remove clamshell from runservers and required repos

### DIFF
--- a/required_repos.txt
+++ b/required_repos.txt
@@ -10,5 +10,4 @@ gatekeeper
 styx
 jellyfish
 blip
-clamshell
 chrome-uploader

--- a/runservers
+++ b/runservers
@@ -291,23 +291,6 @@ tp_blip() {
     echo "Blip started at http://localhost:$PORT"
 }
 
-# clamshell
- tp_clamshell() {
-    export PORT=3004
-    export MOCK=false
-    export API_HOST="http://localhost:8009"
-
-    if [ "$SKIP_BUILD" != "true" ]; then
-      echo "Building Clamshell..."
-      cd clamshell || return
-      npm run build > /dev/null
-      cd ..
-    fi
-
-    tp_start_server clamshell server.js
-    echo "Clamshell started at http://localhost:$PORT"
- }
-
 # NOTE: If you modify this list, please also modify required_repos.txt.
 
 tp_warmup
@@ -325,4 +308,3 @@ tp_gatekeeper || return
 tp_styx || return
 tp_jellyfish || return
 tp_blip || return
-tp_clamshell || return


### PR DESCRIPTION
@darinkrauss @jh-bate 

For some reason when setting up dev environment on my MBA, clamshell was vomiting all over my terminal (nothing that caused anything to break, just super noisy and annoying). This is my solution 😝

I think we still have clamshell deployed, so if you don't want to merge until it's actually nixed, that's cool. (In that case, then we should also modify `checkServerStatus.sh` accordingly before merge.)