### PR TITLE
add nvm commands to use node v0.12 for backend services but node v6 for blip

### DIFF
--- a/runservers
+++ b/runservers
@@ -41,6 +41,7 @@
 
 
 tp_warmup() {
+    nvm use v0.12
     export TP_PIDS=
 }
 
@@ -263,6 +264,7 @@ tp_styx() {
 
 # blip
 tp_blip() {
+    nvm use v6
     export PORT=3000
     export MOCK=false
     export API_HOST="http://localhost:8009"


### PR DESCRIPTION
As y'all surely know, ops is not my forte. However, this seems to work. So for expediency's sake if it's not horrifyingly objectionable, perhaps it's enough for now? CC @jh-bate 