### PR TITLE
Use common server log for go services

### DIFF
--- a/runservers
+++ b/runservers
@@ -98,11 +98,12 @@ tp_start_server() {   # expects servername, start name
 tp_go_server() {
     REPO="${1}"
     echo "Starting ${REPO}"
-    export GOPATH="${PWD}/${REPO}"
+    TP_DIR="${PWD}"
+    export GOPATH="${TP_DIR}/${REPO}"
     pushd "${GOPATH}/src/github.com/tidepool-org/${REPO}"
 	# use the first line if you want individual logs, the 2nd if you want to aggregate them.
-	# ./dist/${REPO} > ../${REPO}.log 2>&1 &
-	./dist/${REPO} >> ../server.log 2>&1 &
+	# ./dist/${REPO} > ${TP_DIR}/${REPO}.log 2>&1 &
+	./dist/${REPO} >> ${TP_DIR}/server.log 2>&1 &
 	PIDDY=${!}
 	echo "Started ${REPO}, pid ${PIDDY}"
 	export TP_PIDS="${TP_PIDS} ${PIDDY}"


### PR DESCRIPTION
@pazaan The existing code creates a log in the parent directory that contains the repo. Since the Go repos have now moved into a valid Go path, we need to remember the Tidepool parent directory and store logs there instead.