### PR TITLE
Performance improvements for 'blip' and 'viz' docker services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ After that, usage is as follows:
 | `tidepool unlink service package`        | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
 | `tidepool list`                          | list running services in the tidepool stack                                                                                                                 |
 | `tidepool [node_service] [...cmds]`      | shortcut to run yarn commands against the specified service                                                                                                 |
+| `tidepool api [...cmds]`                 | wrapper for the 'tapi' cli tool in the 'tools' service                                                                                                      |
 | `tidepool help`                          | show more detailed usage text than what's listed here                                                                                                       |
 
 ## Development VM using Vagrant

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ After that, usage is as follows:
 | `tidepool up`                            | start and/or (re)build the tidepool stack                                                                                                                   |
 | `tidepool down`                          | shut down the tidepool stack                                                                                                                                |
 | `tidepool restart [service]`             | restart the entire tidepool stack or the specified service                                                                                                  |
+| `tidepool pull [service]`                | pull the latest images for the entire tidepool stack or the specified service                                                                               |
 | `tidepool logs [service]`                | tail logs for the entire tidepool stack or the specified service                                                                                            |
 | `tidepool run service [...cmds]`         | run arbitrary shell commands against a service                                                                                                              |
 | `tidepool link service dir`              | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ After that, usage is as follows:
 | `tidepool restart [service]`             | restart the entire tidepool stack or the specified service                                                                                                  |
 | `tidepool pull [service]`                | pull the latest images for the entire tidepool stack or the specified service                                                                               |
 | `tidepool logs [service]`                | tail logs for the entire tidepool stack or the specified service                                                                                            |
-| `tidepool build [service]`               | (re)build the image for all services in the tidepool stack or the specified service                                                                         |
+| `tidepool rebuild [service]`             | rebuild and run image for all services in the tidepool stack or the specified service                                                                       |
 | `tidepool run service [...cmds]`         | run arbitrary shell commands against a service                                                                                                              |
 | `tidepool link service dir`              | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
 | `tidepool unlink service dir`            | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When you have finished using the environment, you can press `CTRL + C` to shutdo
 |---------------------------|-----------------------------------------------------|---------------------------------------------------|------------------------------------------------------------------------------------------|
 | `mongo`                   | MongoDB for data storage                            | Instance of the standard MongoDB Docker container | `TP_MONGO_DATA_DIR`: local directory to store MongoDB data files                         |
 | `tidepool/blip`           | The Tidepool Web App                                | https://github.com/tidepool-org/blip              | `TP_BLIP_DIR`: local directory where the `blip` repository is cloned                     |
-| `tidepool/viz` (optional) | The Tidepool Viz App                                | https://github.com/tidepool-org/viz               | `TP_VIZ_DIR`: local directory where the `viz` repository is cloned                     |
+| `tidepool/viz` (optional) | The Tidepool Viz App                                | https://github.com/tidepool-org/viz               | `TP_VIZ_DIR`: local directory where the `viz` repository is cloned                       |
 | `tidepool/dataservices`   | Current generation upload service                   | https://github.com/tidepool-org/platform          | `TP_PLATFORM_DIR`: local directory where the `platform` repository is cloned             |
 | `tidepool/gatekeeper`     | Authorization client and server for tidepool        | https://github.com/tidepool-org/gatekeeper        | `TP_GATEKEEPER_DIR`: local directory where the `gatekeeper` repository is cloned         |
 | `tidepool/hakken`         | Discovery service                                   | https://github.com/tidepool-org/hakken            | `TP_HAKKEN_DIR`: local directory where the `hakken` repository is cloned                 |
@@ -87,7 +87,8 @@ When you have finished using the environment, you can press `CTRL + C` to shutdo
 | `docker-compose up`           | start up the containers in interactive mode (shows logs). Press `CTRL + C` to exit                                                              |
 | `docker-compose up -d`        | start up the containers in non-interactive mode                                                                                                 |
 | `docker-compose ps`           | show the list of running Tidepool containers                                                                                                    |
-| `docker-compose down`         | shut down the containers, and remove the virtual networks                                                                                       |
+| `docker-compose stop`         | shut down the containers                                                                                                                        |
+| `docker-compose down`         | shut down and remove the containers and volumes, and remove the virtual networks                                                                |
 | `docker-compose logs`         | shows logs for all of the containers                                                                                                            |
 | `docker-compose logs blip`    | shows logs for just the `blip` container. Use different container names to see other logs                                                       |
 | `docker-compose logs -f styx` | shows logs for just the `styx` container, and follows the log output (similar to `tail -f`). Use different container names to follow other logs |
@@ -150,7 +151,7 @@ To link `tideline` in the `blip` container:
 * In a terminal window, make sure that you're in the same directory as the `docker-compose.yml` file.
 * Set the optional Environment Variable for both the `blip` and `tideline` repositories:
   * For example, `export TP_BLIP_DIR=$PWD/blip` and `export TP_TIDELINE_DIR=$PWD/tideline`
-* Edit the `docker-compose.yml`, and un-comment the `/app` and `/tideline` volumes from the `volumes` section for the `blip` service (you only need to do this once).
+* Edit the `docker-compose.yml`, and un-comment all the volumes with mount paths beginning with `/app` and `/tideline` from the `volumes` section for the `blip` service (you only need to do this once).
 * Link `tideline` in your container by running the following (you only need to do this once):
   * `docker-compose up -d`
   * `docker-compose run blip /bin/sh -c "cd /tideline && yarn link && cd /app && yarn link tideline"`
@@ -177,23 +178,28 @@ In that case, you can run it from any location in your filesystem, which is very
 Before using this tool, you need to set the TP_BASE_DIR environment variable to the location of your docker-compose.yml file for the tidepool stack.
 i.e. `export TP_BASE_DIR="/Users/MY_USER/tidepool"`
 
-After that, usage is as follows:
+### Overriding the default docker-compose.yml file
+If you also have a docker-compose.override.yml file in your base Tidepool directory, it will be overlayed atop the main compose file, allowing you to make local changes to the stack without modifying the main docker-compose.yml file.  This will work while using the `tidepool` helper script, or the standard `docker-compose` tool.
 
-| Use command...                           | When you want to                                                                                                                                            |
-|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `tidepool up`                            | start and/or (re)build the tidepool stack                                                                                                                   |
-| `tidepool down`                          | shut down the tidepool stack                                                                                                                                |
-| `tidepool restart [service]`             | restart the entire tidepool stack or the specified service                                                                                                  |
-| `tidepool pull [service]`                | pull the latest images for the entire tidepool stack or the specified service                                                                               |
-| `tidepool logs [service]`                | tail logs for the entire tidepool stack or the specified service                                                                                            |
-| `tidepool rebuild [service]`             | rebuild and run image for all services in the tidepool stack or the specified service                                                                       |
-| `tidepool run service [...cmds]`         | run arbitrary shell commands against a service                                                                                                              |
-| `tidepool link service package`          | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
-| `tidepool unlink service package`        | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
-| `tidepool list`                          | list running services in the tidepool stack                                                                                                                 |
-| `tidepool [node_service] [...cmds]`      | shortcut to run yarn commands against the specified service                                                                                                 |
-| `tidepool api [...cmds]`                 | wrapper for the 'tapi' cli tool in the 'tools' service                                                                                                      |
-| `tidepool help`                          | show more detailed usage text than what's listed here                                                                                                       |
+See [Understanding multiple Compose files](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files) for full details.
+
+Once you have your base Tidepool directory set up, usage of the `tidepool` script is as follows:
+
+| Use command...                      | When you want to                                                                                                                                            |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `tidepool up`                       | start and/or (re)build the tidepool stack                                                                                                                   |
+| `tidepool down`                     | shut down the tidepool stack                                                                                                                                |
+| `tidepool restart [service]`        | restart the entire tidepool stack or the specified service                                                                                                  |
+| `tidepool pull [service]`           | pull the latest images for the entire tidepool stack or the specified service                                                                               |
+| `tidepool logs [service]`           | tail logs for the entire tidepool stack or the specified service                                                                                            |
+| `tidepool rebuild [service]`        | rebuild and run image for all services in the tidepool stack or the specified service                                                                       |
+| `tidepool run service [...cmds]`    | run arbitrary shell commands against a service                                                                                                              |
+| `tidepool link service package`     | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
+| `tidepool unlink service package`   | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
+| `tidepool list`                     | list running services in the tidepool stack                                                                                                                 |
+| `tidepool [node_service] [...cmds]` | shortcut to run yarn commands against the specified service                                                                                                 |
+| `tidepool api [...cmds]`            | wrapper for the 'tapi' cli tool in the 'tools' service                                                                                                      |
+| `tidepool help`                     | show more detailed usage text than what's listed here                                                                                                       |
 
 ## Development VM using Vagrant
 Tidepool also has a VM for quickly firing up a development environment on your local machine.

--- a/README.md
+++ b/README.md
@@ -103,13 +103,15 @@ To prepare your repository clone for development:
 * In a terminal window, make sure that you're in the same directory as the `docker-compose.yml` file.
 * Set the optional Environment Variable for the repository you're working on.
   * If you were working on `dataservices`, you would `export TP_PLATFORM_DIR=<Full path to platform clone>`, for example `export TP_PLATFORM_DIR=$PWD/platform`
-* Edit the `docker-compose.yml`, and un-comment  the `build` section for the corresponding service (you only need to do this once).
+* Edit the `docker-compose.yml`, and un-comment  the `build` and `volumes` section for the corresponding service (you only need to do this once).
 
-Every time you want to test changes against the code you've modified locally, run:
-* `docker-compose build`; then
-* `docker-compose up -d` (you **don't** have to run `docker-compose down` first)
+The golang services will automatically watch for changes made to `.go` and `.c` files, and will rebuild the service automatically when they occur.
 
-`docker-compose` will detect that the container has changed, and recreate and restart only the changed container.
+If you need to make a change to a file that's not under watch, such as a JSON config file, you will need to rebuild the image against the code you've modified locally, with:
+* `docker-compose build [service]`; then
+* `docker-compose up -d [service]` (you **don't** have to run `docker-compose down` first)
+
+`docker-compose` will detect that the container has changed, and recreate and restart only the changed container. If you specify the service via the optional `service` arg, only that service will be rebuilt.  Otherwise, all services will be scanned for changes, and will be rebuilt as required.
 
 ##### Node-based containers
 To prepare your repository clone for development:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ After that, usage is as follows:
 | `tidepool restart [service]`             | restart the entire tidepool stack or the specified service                                                                                                  |
 | `tidepool pull [service]`                | pull the latest images for the entire tidepool stack or the specified service                                                                               |
 | `tidepool logs [service]`                | tail logs for the entire tidepool stack or the specified service                                                                                            |
+| `tidepool build [service]`               | (re)build the image for all services in the tidepool stack or the specified service                                                                         |
 | `tidepool run service [...cmds]`         | run arbitrary shell commands against a service                                                                                                              |
 | `tidepool link service dir`              | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
 | `tidepool unlink service dir`            | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Before using this tool, you need to set the TP_BASE_DIR environment variable to 
 i.e. `export TP_BASE_DIR="/Users/MY_USER/tidepool"`
 
 After that, usage is as follows:
+
 | Use command...                           | When you want to                                                                                                                                            |
 |------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `tidepool up`                            | start and/or (re)build the tidepool stack                                                                                                                   |
@@ -187,8 +188,8 @@ After that, usage is as follows:
 | `tidepool logs [service]`                | tail logs for the entire tidepool stack or the specified service                                                                                            |
 | `tidepool rebuild [service]`             | rebuild and run image for all services in the tidepool stack or the specified service                                                                       |
 | `tidepool run service [...cmds]`         | run arbitrary shell commands against a service                                                                                                              |
-| `tidepool link service dir`              | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
-| `tidepool unlink service dir`            | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
+| `tidepool link service package`          | yarn link a mounted package and restart the service (package must be mounted into a root directory that matches it's name)                                  |
+| `tidepool unlink service package`        | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
 | `tidepool list`                          | list running services in the tidepool stack                                                                                                                 |
 | `tidepool [node_service] [...cmds]`      | shortcut to run yarn commands against the specified service                                                                                                 |
 | `tidepool help`                          | show more detailed usage text than what's listed here                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ To prepare your repository clone for development:
 * In a terminal window, make sure that you're in the same directory as the `docker-compose.yml` file.
 * Set the optional Environment Variable for the repository you're working on.
   * If you were working on `dataservices`, you would `export TP_PLATFORM_DIR=<Full path to platform clone>`, for example `export TP_PLATFORM_DIR=$PWD/platform`
-* Edit the `docker-compose.yml`, and un-comment  the `build` and `volumes` section for the corresponding service (you only need to do this once).
+* Edit the `docker-compose.yml`, and un-comment  the `build` and `volumes` section (if present) for the corresponding service (you only need to do this once).
 
-The golang services will automatically watch for changes made to `.go` and `.c` files, and will rebuild the service automatically when they occur.
+Any golang service with a `volumes` block will automatically watch for changes made to `.go` and `.c` files, and will rebuild the service automatically when they occur.
 
-If you need to make a change to a file that's not under watch, such as a JSON config file, you will need to rebuild the image against the code you've modified locally, with:
+If you need to make a change to a file that's not under watch, such as a JSON config file, or for golang services without a volume mount, you will need to rebuild the image against the code you've modified locally, with:
 * `docker-compose build [service]`; then
 * `docker-compose up -d [service]` (you **don't** have to run `docker-compose down` first)
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ Once you have your base Tidepool directory set up, usage of the `tidepool` scrip
 | `tidepool unlink service package`   | yarn unlink a mounted package, reinstall the remote package, and restart the service (package must be mounted into a root directory that matches it's name) |
 | `tidepool list`                     | list running services in the tidepool stack                                                                                                                 |
 | `tidepool [node_service] [...cmds]` | shortcut to run yarn commands against the specified service                                                                                                 |
-| `tidepool api [...cmds]`            | wrapper for the 'tapi' cli tool in the 'tools' service                                                                                                      |
 | `tidepool help`                     | show more detailed usage text than what's listed here                                                                                                       |
 
 ## Development VM using Vagrant

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
     image: tidepool/hydrophone
     container_name: hydrophone
     # build: $TP_HYDROPHONE_DIR
+    # volumes:
+    #   - $TP_HYDROPHONE_DIR:/go/src/github.com/tidepool-org/hydrophone
+    #   - hydrophone-config:/go/src/github.com/tidepool-org/hydrophone/config
     links:
       - mongo
       - hakken
@@ -245,6 +248,7 @@ services:
 
 volumes:
   mongo-data:
+  hydrophone-config:
 
 networks:
   front-tier:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,25 +186,6 @@ services:
     ports:
       - '9221:9221'
 
-  # tools:
-  #   image: tidepool/tools
-  #   container_name: tools
-  #   # build:
-  #   #  context: $TP_PLATFORM_DIR
-  #   #  dockerfile: Dockerfile.tools
-  #   # volumes:
-  #   # - $TP_PLATFORM_DIR:/go/src/github.com/tidepool-org/platform
-  #   # - platform-config:/go/src/github.com/tidepool-org/platform/_config
-  #   links:
-  #     - hakken
-  #     - mongo
-  #     - styx
-  #     - userservices
-  #     - dataservices
-  #   networks:
-  #     - back-tier
-  #     - front-tier
-
   # viz:
   #   image: tidepool/viz
   #   container_name: viz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,7 @@ services:
   #   volumes:
   #     - $TP_VIZ_DIR:/app:cached
   #     - viz-modules:/app/node_modules
-  #     - /app/dist
+  #     - viz-dist:/app/dist
   #   environment:
   #     NODE_ENV: development
   #   ports:
@@ -209,6 +209,7 @@ services:
 
       # - $TP_VIZ_DIR:/@tidepool/viz:cached
       # - viz-modules:/@tidepool/viz/node_modules:ro
+      # - viz-dist:/@tidepool/viz/dist:ro
 
       # - $TP_TIDELINE_DIR:/tideline:cached
       # - /tideline/node_modules
@@ -317,6 +318,7 @@ volumes:
   hydrophone-config:
   platform-config:
   viz-modules:
+  viz-dist:
 
 networks:
   front-tier:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
   #   container_name: viz
   #   volumes:
   #     - $TP_VIZ_DIR:/app:cached
-  #     - viz-modules:/app/node_modules
+  #     - /app/node_modules
   #     - viz-dist:/app/dist
   #   environment:
   #     NODE_ENV: development
@@ -208,7 +208,6 @@ services:
       # - /app/dist
 
       # - $TP_VIZ_DIR:/@tidepool/viz:cached
-      # - viz-modules:/@tidepool/viz/node_modules:ro
       # - viz-dist:/@tidepool/viz/dist:ro
 
       # - $TP_TIDELINE_DIR:/tideline:cached
@@ -317,7 +316,6 @@ volumes:
   mongo-data:
   hydrophone-config:
   platform-config:
-  viz-modules:
   viz-dist:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,9 @@ services:
     # build:
     #  context: $TP_PLATFORM_DIR
     #  dockerfile: Dockerfile.dataservices
+    # volumes:
+    # - $TP_PLATFORM_DIR:/go/src/github.com/tidepool-org/platform
+    # - platform-config:/go/src/github.com/tidepool-org/platform/_config
     links:
       - hakken
       - mongo
@@ -119,6 +122,9 @@ services:
     # build:
     #  context: $TP_PLATFORM_DIR
     #  dockerfile: Dockerfile.userservices
+    # volumes:
+    # - $TP_PLATFORM_DIR:/go/src/github.com/tidepool-org/platform
+    # - platform-config:/go/src/github.com/tidepool-org/platform/_config
     links:
       - hakken
       - mongo
@@ -130,6 +136,25 @@ services:
       - front-tier
     ports:
       - '8078:8078'
+
+  # tools:
+  #   image: tidepool/tools
+  #   container_name: tools
+  #   # build:
+  #   #  context: $TP_PLATFORM_DIR
+  #   #  dockerfile: Dockerfile.tools
+  #   # volumes:
+  #   # - $TP_PLATFORM_DIR:/go/src/github.com/tidepool-org/platform
+  #   # - platform-config:/go/src/github.com/tidepool-org/platform/_config
+  #   links:
+  #     - hakken
+  #     - mongo
+  #     - styx
+  #     - userservices
+  #     - dataservices
+  #   networks:
+  #     - back-tier
+  #     - front-tier
 
   # viz:
   #   image: tidepool/viz
@@ -249,6 +274,7 @@ services:
 volumes:
   mongo-data:
   hydrophone-config:
+  platform-config:
 
 networks:
   front-tier:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,19 +210,30 @@ services:
   #   container_name: viz
   #   volumes:
   #     - $TP_VIZ_DIR:/app:cached
+  #     - viz-modules:/app/node_modules
+  #     - /app/dist
   #   environment:
   #     NODE_ENV: development
   #   ports:
   #     - '8081:8081'
+  #     - '8082:8082'
 
   blip:
     image: tidepool/blip
     container_name: blip
     # volumes:
-    #   - $TP_BLIP_DIR:/app:cached
-    #   - $TP_VIZ_DIR:/@tidepool/viz:cached
-    #   - $TP_TIDELINE_DIR:/tideline:cached
-    #   - $TP_TIDEPOOL_PLATFORM_CLIENT_DIR:/tidepool-platform-client:cached
+      # - $TP_BLIP_DIR:/app:cached
+      # - /app/node_modules
+      # - /app/dist
+
+      # - $TP_VIZ_DIR:/@tidepool/viz:cached
+      # - viz-modules:/@tidepool/viz/node_modules:ro
+
+      # - $TP_TIDELINE_DIR:/tideline:cached
+      # - /tideline/node_modules
+
+      # - $TP_TIDEPOOL_PLATFORM_CLIENT_DIR:/tidepool-platform-client:cached
+      # - /tidepool-platform-client/node_modules
     environment:
       NODE_ENV: development
       DEV_TOOLS: ${DEV_TOOLS:-true}
@@ -324,6 +335,7 @@ volumes:
   mongo-data:
   hydrophone-config:
   platform-config:
+  viz-modules:
 
 networks:
   front-tier:

--- a/tidepool
+++ b/tidepool
@@ -23,6 +23,7 @@ Usage: tidepool command [service] [...additional args]
     up [service]                    start and/or (re)build the entire tidepool stack or the specified service
     down [service]                  shut down the entire tidepool stack or the specified service
     restart [service]               restart the entire tidepool stack or the specified service
+    pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service
 
     run service [...cmds]          run arbitrary shell commands against a service
@@ -67,6 +68,7 @@ case $1 in
   up) (cd $TP_BASE_DIR && exec docker-compose up -d $2);;
   down) (cd $TP_BASE_DIR && exec docker-compose down $2);;
   restart) restart $2;;
+  pull) (cd $TP_BASE_DIR && exec docker-compose pull $2);;
   logs) (cd $TP_BASE_DIR && exec docker-compose logs --tail=2000 -f $2);;
   run) run $2 ${@:3};;
   link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${4:-$3}") && restart $2;;

--- a/tidepool
+++ b/tidepool
@@ -34,13 +34,13 @@ Usage: tidepool command [service] [...additional args]
     run service [...cmds]          run arbitrary shell commands against a service
                                       example: 'tidepool run blip sh' (to enter the container's shell)
 
-    link service dir                yarn link a mounted package and restart the service
+    link service package            yarn link a mounted package and restart the service
                                     NOTE: the package must be mounted into a root directory that matches it's name
                                       example: 'tidepool link blip @tidepool/viz'
                                         - will link the package mounted at /@tidepool/viz and link the
                                           "@tidepool/viz" package in blip.
 
-    unlink service dir              yarn unlink a mounted package, reinstall the remote package, and restart
+    unlink service package          yarn unlink a mounted package, reinstall the remote package, and restart
                                     NOTE: the package must be mounted into a root directory that matches it's name
                                       example: 'tidepool unlink blip tideline'
                                         - will link the package mounted at /tideline and unlink

--- a/tidepool
+++ b/tidepool
@@ -25,7 +25,9 @@ Usage: tidepool command [service] [...additional args]
     restart [service]               restart the entire tidepool stack or the specified service
     pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service
-    build [service]                 (re)build the image for all services in the tidepool stack or the specified service
+
+    rebuild [service]               rebuild and run image for all services in the tidepool stack
+                                    or the specified service
                                     NOTE: the service(s) must have a 'build' property in the 'docker-compose.yml'
                                     file for this to have any effect.
 
@@ -73,7 +75,7 @@ case $1 in
   restart) restart $2;;
   pull) (cd $TP_BASE_DIR && exec docker-compose pull $2);;
   logs) (cd $TP_BASE_DIR && exec docker-compose logs --tail=2000 -f $2);;
-  build) (cd $TP_BASE_DIR && exec docker-compose build $2);;
+  rebuild) (cd $TP_BASE_DIR && docker-compose build $2 && exec docker-compose up -d $2);;
   run) run $2 ${@:3};;
   link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${4:-$3}") && restart $2;;
   unlink) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "yarn unlink ${4:-$3}; cd /${3} && yarn unlink; cd /app && yarn install --force") && restart $2;;

--- a/tidepool
+++ b/tidepool
@@ -60,6 +60,8 @@ Usage: tidepool command [service] [...additional args]
                                     backend node services are one of:
                                     [hakken|gatekeeper|highwater|jellyfish|message-api|seagull|styx]
 
+    api                             wrapper for the 'tapi' cli tool in the optional 'tools' service
+
     help                            show this help text
 
 EOF
@@ -82,5 +84,6 @@ case $1 in
   list) (cd $TP_BASE_DIR && exec docker-compose ps);;
   $NODE_SERVICES) run $1 "yarn ${@:2}";;
   $BLIP_MOUNTED_NODE_SERVICES) run blip "cd /${1} && yarn ${@:2}";;
+  api) run tools "./_bin/tools/tapi/tapi ${@:2}";;
   *|help) usage;;
 esac

--- a/tidepool
+++ b/tidepool
@@ -61,8 +61,6 @@ USAGE: tidepool command [service] [...additional args]
                                     backend node services are one of:
                                     [hakken|gatekeeper|highwater|jellyfish|message-api|seagull|styx]
 
-    api                             wrapper for the 'tapi' cli tool in the optional 'tools' service
-
     help                            show this help text
 
 
@@ -102,6 +100,5 @@ case $1 in
   list) (cd $TP_BASE_DIR && docker-compose-override ps);;
   $NODE_SERVICES) run-exec $1 "yarn ${@:2}";;
   $BLIP_MOUNTED_NODE_SERVICES) run-exec blip "cd /${1} && yarn ${@:2}";;
-  api) run tools "./_bin/tools/tapi/tapi ${@:2}";;
   *|help) usage;;
 esac

--- a/tidepool
+++ b/tidepool
@@ -5,7 +5,7 @@ if [ -z "$TP_BASE_DIR" ]; then
   cat <<EOF
 =====================================================================
 You need to set the TP_BASE_DIR environment variable to the location
-of your docker-compose.yml file for the tidepool stack
+of your docker-compose.yml file for the tidepool stack.
 
 EOF
   exit 1
@@ -17,11 +17,12 @@ BLIP_MOUNTED_NODE_SERVICES='@(tideline|tidepool-platform-client)'
 usage() {
   cat <<EOF
 =======================================================
-Usage: tidepool command [service] [...additional args]
+USAGE: tidepool command [service] [...additional args]
 
   commands:
     up [service]                    start and/or (re)build the entire tidepool stack or the specified service
-    down [service]                  shut down the entire tidepool stack or the specified service
+    down [service]                  shut down and remove the entire tidepool stack or the specified service
+    stop [service]                  shut down the entire tidepool stack or the specified service
     restart [service]               restart the entire tidepool stack or the specified service
     pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service
@@ -64,26 +65,43 @@ Usage: tidepool command [service] [...additional args]
 
     help                            show this help text
 
+
+ADDITIONAL TIPS:
+  If you also have a docker-compose.override.yml file in this directory,
+  it will be overlayed atop the main compose file, allowing you to
+  make local changes without modifying the main docker-compose.yml file.
+
 EOF
 }
 
-restart() { (cd $TP_BASE_DIR && docker-compose stop $1 && exec docker-compose start $1); }
+restart() { (cd $TP_BASE_DIR && docker-compose stop $1 && docker-compose-override start $1); }
 
-run() { args=${@:2} && (cd $TP_BASE_DIR && exec docker-compose exec $1 /bin/sh -c "${args}") }
+run() { args="${@:2}" && (cd $TP_BASE_DIR && docker-compose-override run --rm $1 /bin/sh -c ${args// /:::}) }
+
+run-exec() { args="${@:2}" && (cd $TP_BASE_DIR && docker-compose-override exec $1 /bin/sh -c ${args// /:::}) }
+
+docker-compose-override() {
+  if [ -f docker-compose.override.yml ]; then
+    exec docker-compose -f docker-compose.yml -f docker-compose.override.yml "${@//:::/ }"
+  else
+    exec docker-compose "${@//:::/ }"
+  fi
+}
 
 case $1 in
-  up) (cd $TP_BASE_DIR && exec docker-compose up -d $2);;
-  down) (cd $TP_BASE_DIR && exec docker-compose down $2);;
+  up) (cd $TP_BASE_DIR && docker-compose-override up -d $2);;
+  down) (cd $TP_BASE_DIR && docker-compose-override down $2);;
+  stop) (cd $TP_BASE_DIR && docker-compose-override stop $2);;
   restart) restart $2;;
-  pull) (cd $TP_BASE_DIR && exec docker-compose pull $2);;
-  logs) (cd $TP_BASE_DIR && exec docker-compose logs --tail=2000 -f $2);;
-  rebuild) (cd $TP_BASE_DIR && docker-compose build $2 && exec docker-compose up -d $2);;
+  pull) (cd $TP_BASE_DIR && docker-compose-override pull $2);;
+  logs) (cd $TP_BASE_DIR && docker-compose-override logs --tail=20 -f $2);;
+  rebuild) (cd $TP_BASE_DIR && docker-compose build $2 && docker-compose-override up -d $2);;
   run) run $2 ${@:3};;
-  link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${3}") && restart $2;;
-  unlink) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "yarn unlink ${3}; cd /${3} && yarn unlink; cd /app && rm -f node_modules/${3} && yarn install --force") && restart $2;;
-  list) (cd $TP_BASE_DIR && exec docker-compose ps);;
-  $NODE_SERVICES) run $1 "yarn ${@:2}";;
-  $BLIP_MOUNTED_NODE_SERVICES) run blip "cd /${1} && yarn ${@:2}";;
+  link) (cd $TP_BASE_DIR && docker-compose-override exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${3}") && restart $2;;
+  unlink) (cd $TP_BASE_DIR && docker-compose-override exec $2 /bin/sh -c "yarn unlink ${3}; cd /${3} && yarn unlink; cd /app && rm -f node_modules/${3} && yarn install --force") && restart $2;;
+  list) (cd $TP_BASE_DIR && docker-compose-override ps);;
+  $NODE_SERVICES) run-exec $1 "yarn ${@:2}";;
+  $BLIP_MOUNTED_NODE_SERVICES) run-exec blip "cd /${1} && yarn ${@:2}";;
   api) run tools "./_bin/tools/tapi/tapi ${@:2}";;
   *|help) usage;;
 esac

--- a/tidepool
+++ b/tidepool
@@ -25,6 +25,9 @@ Usage: tidepool command [service] [...additional args]
     restart [service]               restart the entire tidepool stack or the specified service
     pull [service]                  pull the latest images for the entire tidepool stack or the specified service
     logs [service]                  tail logs for the entire tidepool stack or the specified service
+    build [service]                 (re)build the image for all services in the tidepool stack or the specified service
+                                    NOTE: the service(s) must have a 'build' property in the 'docker-compose.yml'
+                                    file for this to have any effect.
 
     run service [...cmds]          run arbitrary shell commands against a service
                                       example: 'tidepool run blip sh' (to enter the container's shell)
@@ -70,6 +73,7 @@ case $1 in
   restart) restart $2;;
   pull) (cd $TP_BASE_DIR && exec docker-compose pull $2);;
   logs) (cd $TP_BASE_DIR && exec docker-compose logs --tail=2000 -f $2);;
+  build) (cd $TP_BASE_DIR && exec docker-compose build $2);;
   run) run $2 ${@:3};;
   link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${4:-$3}") && restart $2;;
   unlink) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "yarn unlink ${4:-$3}; cd /${3} && yarn unlink; cd /app && yarn install --force") && restart $2;;

--- a/tidepool
+++ b/tidepool
@@ -77,8 +77,8 @@ case $1 in
   logs) (cd $TP_BASE_DIR && exec docker-compose logs --tail=2000 -f $2);;
   rebuild) (cd $TP_BASE_DIR && docker-compose build $2 && exec docker-compose up -d $2);;
   run) run $2 ${@:3};;
-  link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${4:-$3}") && restart $2;;
-  unlink) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "yarn unlink ${4:-$3}; cd /${3} && yarn unlink; cd /app && yarn install --force") && restart $2;;
+  link) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "cd /${3} && yarn link && cd /app && yarn link ${3}") && restart $2;;
+  unlink) (cd $TP_BASE_DIR && exec docker-compose exec $2 /bin/sh -c "yarn unlink ${3}; cd /${3} && yarn unlink; cd /app && rm -f node_modules/${3} && yarn install --force") && restart $2;;
   list) (cd $TP_BASE_DIR && exec docker-compose ps);;
   $NODE_SERVICES) run $1 "yarn ${@:2}";;
   $BLIP_MOUNTED_NODE_SERVICES) run blip "cd /${1} && yarn ${@:2}";;


### PR DESCRIPTION
Goes hand-in-hand with:
https://github.com/tidepool-org/viz/pull/93
https://github.com/tidepool-org/blip/pull/451

- Changes to the `docker-compose.yml` 
  - allow us to not volume-mount the `node_modules` and `dist` directories to improve local performance in the `blip` and `viz` services.
- Updates to the `tidepool` helper script
  - added `tidepool stop` command
  - added `tidepool pull` command
  - added `tidepool api` command
- Documentation updates
  - new helper script commands
  - instructions for overriding the default docker-compose.yml file with an override compose file