### PR TITLE
Tag and push on all builds.

### DIFF
--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -1,7 +1,8 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 
 if [ "${TRAVIS_NODE_VERSION}" != "${ARTIFACT_NODE_VERSION}" ]; then
-    exit 0
+    echo "Travis Node version does not match Artifact Node version"
+    exit 1
 fi
 
 if [ -n "${TRAVIS_TAG:-}" ]; then
@@ -31,17 +32,22 @@ if [ -n "${TRAVIS_TAG:-}" ]; then
     rm -rf "${TMP_DIR}/"
 fi
 
-if [ "${TRAVIS_BRANCH:-}" == "master" -a "${TRAVIS_PULL_REQUEST_BRANCH:-}" == "" -o -n "${TRAVIS_TAG:-}" ]; then
+if [ -n "${DOCKER_USERNAME:-}" -a -n "${DOCKER_PASSWORD:-}"  ]; then
     DOCKER_REPO="tidepool/${TRAVIS_REPO_SLUG#*/}"
-
     echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-
-    docker build --tag "${DOCKER_REPO}" .
+    docker build --tag ${DOCKER_REPO} .
+    
     if [ "${TRAVIS_BRANCH:-}" == "master" -a "${TRAVIS_PULL_REQUEST_BRANCH:-}" == "" ]; then
-        docker push "${DOCKER_REPO}"
+        docker push ${DOCKER_REPO}
     fi
     if [ -n "${TRAVIS_TAG:-}" ]; then
-        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TRAVIS_TAG}"
-        docker push "${DOCKER_REPO}:${TRAVIS_TAG}"
+        docker tag ${DOCKER_REPO} ${DOCKER_REPO}:${TRAVIS_TAG}
+        docker push ${DOCKER_REPO}:${TRAVIS_TAG}
     fi
+    if [ -n "${TRAVIS_BRANCH:-}" -a -n "${TRAVIS_COMMIT:-}" ]; then
+        docker tag ${DOCKER_REPO} ${DOCKER_REPO}:${TRAVIS_BRANCH}-${TRAVIS_COMMIT}
+        docker push ${DOCKER_REPO}:${TRAVIS_BRANCH}-${TRAVIS_COMMIT}
+    fi
+else
+    echo "Missing DOCKER_USERNAME or DOCKER_PASSWORD."
 fi


### PR DESCRIPTION
These changes will result in the CI system building Docker images, tagging them, and pushing them to Docker Hub on practically all builds that pass unit tests.

In addition, better error messages are provided when the version tags are mismatched.

@pazaan Tested on hydrophone.  Same code for Node artifacts.