### PR TITLE
[WEB-728] Use Docker BuildKit for blip builds

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -70,7 +70,7 @@ publish_to_dockerhub() {
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
         if [ "${TRAVIS_REPO_SLUG:-}" == "blip" ]; then
-            docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" .
+            DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" .
         else
             docker build --tag "${DOCKER_REPO}" .
         fi


### PR DESCRIPTION
Part of [WEB-728]

The new blip Dockerfile needs to be run with Buildkit enabled

Related PRs:
---
tidepool-org/development#88
tidepool-org/blip#655

[WEB-728]: https://tidepool.atlassian.net/browse/WEB-728