### PR TITLE
[WEB-75] Pass TRAVIS_COMMIT into blip docker build for rollbar versioning

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -70,7 +70,7 @@ publish_to_dockerhub() {
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
         if [ "${TRAVIS_REPO_SLUG:-}" == "tidepool-org/blip" ]; then
-            DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" .
+            DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg TRAVIS_COMMIT="${TRAVIS_COMMIT:-}" .
         else
             docker build --tag "${DOCKER_REPO}" .
         fi


### PR DESCRIPTION
Part of [WEB-75]

Adds Travis commit to docker build environment to allow blip build config scripts to set it as the Rollbar VERSION_SHA

Related PR: tidepool-org/blip#660

[WEB-75]: https://tidepool.atlassian.net/browse/WEB-75