### PR TITLE
Allow overriding the default blip feature flags for pull request Travis builds

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -10,8 +10,8 @@ publish_to_dockerhub() {
         if [ "${TRAVIS_REPO_SLUG:-}" == "tidepool-org/blip" ]; then
             if [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]
             then
-                RX_ENABLED=true
-                CLINICS_ENABLED=true
+                RX_ENABLED="${RX_ENABLED:-true}"
+                CLINICS_ENABLED="${CLINICS_ENABLED:-true}"
             else
                 RX_ENABLED=false
                 CLINICS_ENABLED=false


### PR DESCRIPTION
We currently default having the clinics and prescriptions features enabled on pull request builds, which allows us to share these UIs remotely with the rest of the team on `qa` and `dev` environments.

We need to sometimes turn force these off by setting branch-specific environment variables in the Travis repo settings. 