### PR TITLE
Require explicitly turning on clinic and prescription feature flags in Travis environment

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -8,14 +8,8 @@ publish_to_dockerhub() {
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
         if [ "${TRAVIS_REPO_SLUG:-}" == "tidepool-org/blip" ]; then
-            if [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]
-            then
-                RX_ENABLED="${RX_ENABLED:-true}"
-                CLINICS_ENABLED="${CLINICS_ENABLED:-true}"
-            else
-                RX_ENABLED=false
-                CLINICS_ENABLED=false
-            fi
+            RX_ENABLED="${RX_ENABLED:-false}"
+            CLINICS_ENABLED="${CLINICS_ENABLED:-false}"
             DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg CLINICS_ENABLED="${CLINICS_ENABLED:-}" --build-arg TRAVIS_COMMIT="${TRAVIS_COMMIT:-}" .
         else
             docker build --tag "${DOCKER_REPO}" .


### PR DESCRIPTION
We were previously defaulting the Tidepool Web feature flags `on` for pull request builds, and `off` everywhere else.  
It's better to simply default them to `off` for all builds, and explicitly turn them `on` in the Travis UI on a per-branch basis.