### PR TITLE
Use custom environment vars to determine if feature flags are enabled

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -8,8 +8,8 @@ publish_to_dockerhub() {
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
         if [ "${TRAVIS_REPO_SLUG:-}" == "tidepool-org/blip" ]; then
-            RX_ENABLED="${RX_ENABLED:-false}"
-            CLINICS_ENABLED="${CLINICS_ENABLED:-false}"
+            if [[ ",${CLINICS_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then CLINICS_ENABLED=true; else CLINICS_ENABLED=false; fi
+            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then RX_ENABLED=true; else RX_ENABLED=false; fi
             DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg CLINICS_ENABLED="${CLINICS_ENABLED:-}" --build-arg TRAVIS_COMMIT="${TRAVIS_COMMIT:-}" .
         else
             docker build --tag "${DOCKER_REPO}" .


### PR DESCRIPTION
The prior solution for enabling feature flags wouldn't cover our use cases properly due to the way that Travis handles pull request build branches.

### Problem
Instead of using the pull request source branch to apply our feature flag environment variables to, it uses the base branch.

So, if we set, via the Travis UI:
```
CLINICS_ENABLED 
true
Only available to the clinic-ui-staging branch
```

Now, if we have a a PR for `clinic-ui-staging` that has `develop` as a base, when we push to `clinic-ui-staging`, the Travis branch build will set `CLINICS_ENABLED` to `true`, but the pull request build will set `CLINICS_ENABLED` to `false`, since we did not specify a `CLINICS_ENABLED=true` flag for `develop` as well in the UI.

We could simply add another branch-specific feature flag for the targeted base branch, but that would cause us to have to enable the feature on `master` before we're ready when we have a release candidate PR in testing.

### Proposed Solution
We create a custom env var in the Travis UI (in our example case - `CLINICS_ENABLED_BRANCHES`) that Travis will apply for all builds that contains a comma separated list for branches to enable.  So, in the UI we would set:
```
CLINICS_ENABLED_BRANCHES 
clinic-ui-staging,any-other-branch
Available to all branches
```

Now any matches of `${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}` with our "feature-enable-lists" in our `artifact.sh` script will get the proper feature flags set whether it's a 'branch build' or a 'pull request build'.
