### PR TITLE
Allow falling back to blip general feature flag env variables when not specifically enabled for a branch

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -8,8 +8,10 @@ publish_to_dockerhub() {
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
         if [ "${TRAVIS_REPO_SLUG:-}" == "tidepool-org/blip" ]; then
-            if [[ ",${CLINICS_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then CLINICS_ENABLED=true; else CLINICS_ENABLED=false; fi
-            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then RX_ENABLED=true; else RX_ENABLED=false; fi
+            CLINICS_ENABLED=${CLINICS_ENABLED-false}
+            RX_ENABLED=${RX_ENABLED-false}
+            if [[ ",${CLINICS_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then CLINICS_ENABLED=true; fi
+            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then RX_ENABLED=true; fi
             DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg CLINICS_ENABLED="${CLINICS_ENABLED:-}" --build-arg TRAVIS_COMMIT="${TRAVIS_COMMIT:-}" .
         else
             docker build --tag "${DOCKER_REPO}" .


### PR DESCRIPTION
Context: when in development, enabling feature flags in Travis builds of `blip` is best done by specifying branches specifically.  However, once we go to production with the feature, we likely want that enabled for all branches so that all of our non-production remote builds will have them enabled by default without needing their branches explicitly specified.

This PR allows setting, for instance, a generic RX_ENABLED env var in Travis  which can be applied to all branches as a fallback for branches not listed in the RX_ENABLED_BRANCHES variable.  

If not set in Travis, the default value in our artifact.sh deployment script will be false, so it will not be accidentally deployed to production.  When the time comes to deploy to production, we'll be able to simply set the `RX_ENABLED` var in the Travis settings to `true` for "All Branches" and we're good to go.

I think this pattern will be flexible enough to suit our current needs and future feature flags as they come up.