### PR TITLE
Tag docker images with timestamp so tags are sortable

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -36,6 +36,10 @@ publish_to_dockerhub() {
             docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${BRANCH}-${TRAVIS_COMMIT}"
             docker push "${DOCKER_REPO}:${BRANCH}-${TRAVIS_COMMIT}"
 
+            TIMESTAMP=$(date +%s)
+            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${BRANCH}-${TRAVIS_COMMIT}-${TIMESTAMP}"
+            docker push "${DOCKER_REPO}:${BRANCH}-${TRAVIS_COMMIT}-${TIMESTAMP}"
+
             docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${BRANCH}-latest"
             docker push "${DOCKER_REPO}:${BRANCH}-latest"
         fi


### PR DESCRIPTION
Flux automation controller expects docker image tags to have a sortable component so it can efficiently compute that latest image to be deployed. 