### PR TITLE
[UPLOAD-1068] Add ability to build docker images on CircleCI

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -19,15 +19,15 @@ publish_to_dockerhub() {
         if [ "$CI_PROVIDER" = "travis" ]; then
             REPO_SLUG=$TRAVIS_REPO_SLUG
             COMMIT=$TRAVIS_COMMIT
-            TAG=$TRAVIS_TAG
-            BRANCH=$TRAVIS_BRANCH
-            PR_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+            TAG=${TRAVIS_TAG:-}
+            BRANCH=${TRAVIS_BRANCH:-}
+            PR_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-}
         elif [ "$CI_PROVIDER" = "circle" ]; then
             REPO_SLUG="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             COMMIT=$CIRCLE_SHA1
-            TAG=$CIRCLE_TAG
-            BRANCH=$CIRCLE_BRANCH
-            PR_BRANCH=$CIRCLE_PR_NUMBER
+            TAG=${CIRCLE_TAG:-}
+            BRANCH=${CIRCLE_BRANCH:-}
+            PR_BRANCH=${CIRCLE_PR_NUMBER:-}
         fi
 
         if [ -z "$PR_BRANCH" ]; then

--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -75,7 +75,7 @@ publish_to_dockerhub() {
         docker push "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-${COMMIT}-${TIMESTAMP}"
 
         # Push PR latest image
-        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TDOCKER_BRANCH_LABEL}-latest"
+        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-latest"
         docker push "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-latest"
 
     fi

--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -39,11 +39,10 @@ publish_to_dockerhub() {
         DOCKER_REPO="tidepool/${REPO_SLUG#*/}"
 
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-
-        if [ "${REPO_SLUG:-}" == "tidepool-org/blip" ]; then
+        if [ "${REPO_SLUG:-}" == "tidepool-org/blip" ] || [ "${REPO_SLUG:-}" == "tidepool-org/uploader" ]; then
             # Build blip image
             RX_ENABLED=${RX_ENABLED-false}
-            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH},"* ]]; then RX_ENABLED=true; fi
+            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${PR_BRANCH:-$BRANCH},"* ]]; then RX_ENABLED=true; fi
             DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg LAUNCHDARKLY_CLIENT_TOKEN="${LAUNCHDARKLY_CLIENT_TOKEN:-}" --build-arg REACT_APP_GAID="${REACT_APP_GAID:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg TRAVIS_COMMIT="${COMMIT:-}" .
         else
             # Build other images

--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -71,8 +71,8 @@ publish_to_dockerhub() {
             docker push "${DOCKER_REPO}:${TAG}-${COMMIT}"
 
             TIMESTAMP=$(date +%s)
-            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-${TIMESTAMP}"
-            docker push "${DOCKER_REPO}:${TAG}-${TIMESTAMP}"
+            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-${COMMIT}-${TIMESTAMP}"
+            docker push "${DOCKER_REPO}:${TAG}-${COMMIT}-${TIMESTAMP}"
 
             # Push PR latest image
             docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-latest"

--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -3,85 +3,81 @@
 # This code is meant to be executed within a CI build.
 
 publish_to_dockerhub() {
-    if [ -n "${DOCKER_USERNAME:-}" ] && [ -n "${DOCKER_PASSWORD:-}" ]; then
+    [ -n ${DOCKER_USERNAME:?} ] && [ -n ${DOCKER_PASSWORD:?} ]
 
-        # Determine CI provider
-        if [ -n "${TRAVIS:-}" ]; then
-            CI_PROVIDER="travis"
-        elif [ -n "${CIRCLECI:-}" ]; then
-            CI_PROVIDER="circle"
-        else
-            echo "No known CI provider detected"
-            return 1
-        fi
-
-        # Set common variables
-        if [ "$CI_PROVIDER" = "travis" ]; then
-            REPO_SLUG=$TRAVIS_REPO_SLUG
-            COMMIT=$TRAVIS_COMMIT
-            TAG=${TRAVIS_TAG:-}
-            BRANCH=${TRAVIS_BRANCH:-}
-            PR_NUMBER=${TRAVIS_PULL_REQUEST:-}
-        elif [ "$CI_PROVIDER" = "circle" ]; then
-            REPO_SLUG="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
-            COMMIT=$CIRCLE_SHA1
-            TAG=${CIRCLE_TAG:-}
-            BRANCH=${CIRCLE_BRANCH:-}
-            PR_NUMBER=${CIRCLE_PR_NUMBER:-}
-        fi
-
-        if [ -z "${PR_NUMBER}" ]; then
-            IS_PULL_REQUEST=false
-        else
-            IS_PULL_REQUEST=true
-        fi
-
-        DOCKER_REPO="tidepool/${REPO_SLUG#*/}"
-
-        echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-        if [ "${REPO_SLUG:-}" == "tidepool-org/blip" ] || [ "${REPO_SLUG:-}" == "tidepool-org/uploader" ]; then
-            # Build blip or uploader image
-            RX_ENABLED=${RX_ENABLED-false}
-            if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${BRANCH},"* ]]; then RX_ENABLED=true; fi
-            DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg LAUNCHDARKLY_CLIENT_TOKEN="${LAUNCHDARKLY_CLIENT_TOKEN:-}" --build-arg REACT_APP_GAID="${REACT_APP_GAID:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg TRAVIS_COMMIT="${COMMIT:-}" .
-        else
-            # Build other images
-            docker build --tag "${DOCKER_REPO}" .
-        fi
-
-        if [ "${BRANCH:-}" == "master" ] && [ ${IS_PULL_REQUEST} == false ]; then
-            # Push master branch image
-            docker push "${DOCKER_REPO}"
-        fi
-
-        if [ -n "${TAG:-}" ]; then
-            # Push git tag image
-            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}"
-            docker push "${DOCKER_REPO}:${TAG}"
-        fi
-
-        if [ -n "${BRANCH}" ] && [ -n "$COMMIT" ]; then
-            if [ ${IS_PULL_REQUEST} == true ]; then
-                TAG="PR-${PR_NUMBER}"
-            else
-                TAG=$(echo -n ${BRANCH} | tr / -)
-            fi
-            # Push commit and timestamp images
-            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-${COMMIT}"
-            docker push "${DOCKER_REPO}:${TAG}-${COMMIT}"
-
-            TIMESTAMP=$(date +%s)
-            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-${COMMIT}-${TIMESTAMP}"
-            docker push "${DOCKER_REPO}:${TAG}-${COMMIT}-${TIMESTAMP}"
-
-            # Push PR latest image
-            docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}-latest"
-            docker push "${DOCKER_REPO}:${TAG}-latest"
-
-        fi
-
+    # Determine CI provider
+    if [ -n "${TRAVIS:-}" ]; then
+        CI_PROVIDER="travis"
+    elif [ -n "${CIRCLECI:-}" ]; then
+        CI_PROVIDER="circle"
     else
-        echo "Missing DOCKER_USERNAME or DOCKER_PASSWORD."
+        echo "No known CI provider detected"
+        return 1
+    fi
+
+    # Set common variables
+    if [ "$CI_PROVIDER" = "travis" ]; then
+        REPO_SLUG=${TRAVIS_REPO_SLUG:?}
+        COMMIT=${TRAVIS_COMMIT:?}
+        TAG=${TRAVIS_TAG:-}
+        BRANCH=${TRAVIS_BRANCH:?}
+        PR_NUMBER=${TRAVIS_PULL_REQUEST:-}
+    elif [ "$CI_PROVIDER" = "circle" ]; then
+        REPO_SLUG="${CIRCLE_PROJECT_USERNAME:?}/${CIRCLE_PROJECT_REPONAME:?}"
+        COMMIT=${CIRCLE_SHA1:?}
+        TAG=${CIRCLE_TAG:-}
+        BRANCH=${CIRCLE_BRANCH:?}
+        PR_NUMBER=${CIRCLE_PR_NUMBER:-}
+    fi
+
+    if [ -z "${PR_NUMBER}" ]; then
+        IS_PULL_REQUEST=false
+    else
+        IS_PULL_REQUEST=true
+    fi
+
+    DOCKER_REPO="tidepool/${REPO_SLUG#*/}"
+
+    echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+    if [ "${REPO_SLUG:-}" == "tidepool-org/blip" ] || [ "${REPO_SLUG:-}" == "tidepool-org/uploader" ]; then
+        # Build blip or uploader image
+        RX_ENABLED=${RX_ENABLED-false}
+        if [[ ",${RX_ENABLED_BRANCHES:-}," = *",${BRANCH},"* ]]; then RX_ENABLED=true; fi
+        DOCKER_BUILDKIT=1 docker build --tag "${DOCKER_REPO}" --build-arg ROLLBAR_POST_SERVER_TOKEN="${ROLLBAR_POST_SERVER_TOKEN:-}" --build-arg LAUNCHDARKLY_CLIENT_TOKEN="${LAUNCHDARKLY_CLIENT_TOKEN:-}" --build-arg REACT_APP_GAID="${REACT_APP_GAID:-}" --build-arg RX_ENABLED="${RX_ENABLED:-}" --build-arg TRAVIS_COMMIT="${COMMIT:-}" .
+    else
+        # Build other images
+        docker build --tag "${DOCKER_REPO}" .
+    fi
+
+    if [ "${BRANCH:-}" == "master" ] && [ "${IS_PULL_REQUEST}" == "false" ]; then
+        # Push master branch image
+        docker push "${DOCKER_REPO}"
+    fi
+
+    if [ -n "${TAG:-}" ]; then
+        # Push git tag image
+        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TAG}"
+        docker push "${DOCKER_REPO}:${TAG}"
+    fi
+
+    if [ -n "${BRANCH}" ] && [ -n "$COMMIT" ]; then
+        if [ ${IS_PULL_REQUEST} == true ]; then
+            DOCKER_BRANCH_LABEL="PR-${PR_NUMBER}"
+        else
+            DOCKER_BRANCH_LABEL=${BRANCH//\//-}
+        fi
+        # Push commit and timestamp images
+        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-${COMMIT}"
+        docker push "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-${COMMIT}"
+
+        TIMESTAMP=$(date +%s)
+        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-${COMMIT}-${TIMESTAMP}"
+        docker push "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-${COMMIT}-${TIMESTAMP}"
+
+        # Push PR latest image
+        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${TDOCKER_BRANCH_LABEL}-latest"
+        docker push "${DOCKER_REPO}:${DOCKER_BRANCH_LABEL}-latest"
+
     fi
 
 }


### PR DESCRIPTION
To support [UPLOAD-1068], needed to be able to build docker images on CircleCI (since Uploader needs access to a private submodule and TravisCI only lets you have entirely private or entirely public, not public accessing _some_ private resources).

[UPLOAD-1068]: https://tidepool.atlassian.net/browse/UPLOAD-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ