### PR TITLE
fix for TRAVIS_PULL_REQUEST not matching the rest of the env var APIs

### DIFF
--- a/artifact/artifact.sh
+++ b/artifact/artifact.sh
@@ -21,7 +21,11 @@ publish_to_dockerhub() {
         COMMIT=${TRAVIS_COMMIT:?}
         TAG=${TRAVIS_TAG:-}
         BRANCH=${TRAVIS_BRANCH:?}
-        PR_NUMBER=${TRAVIS_PULL_REQUEST:-}
+        if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+            PR_NUMBER=""
+        else
+            PR_NUMBER=${TRAVIS_PULL_REQUEST}
+        fi
     elif [ "$CI_PROVIDER" = "circle" ]; then
         REPO_SLUG="${CIRCLE_PROJECT_USERNAME:?}/${CIRCLE_PROJECT_REPONAME:?}"
         COMMIT=${CIRCLE_SHA1:?}


### PR DESCRIPTION
TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

Where every other env var provided by Travis is empty string when not applicable to the current build.
